### PR TITLE
Bug fix

### DIFF
--- a/pass/KSym/AnalysisDriver.cpp
+++ b/pass/KSym/AnalysisDriver.cpp
@@ -548,7 +548,8 @@ int SAHandle::postBugAnalysis(TraceStatus* traceStatus,blist & old_blks ,Slice& 
     enum UB_types ub_type = seed2UBType(traceStatus->seed);
     Instruction * sanitized_value = seed2sanitizedVar(traceStatus->seed,ub_type);
 
-    if(ub_type != ub_notype){
+    vector<enum UB_types> unimmediateUBTypes {uadd, usub, umul, sadd, ssub, smul, negate_overflow, shift_out_of_bound};
+    if(find(unimmediateUBTypes.begin(),unimmediateUBTypes.end(),ub_type) != unimmediateUBTypes.end()) {
         // this is a UB that needs to be post-bug analyzed
         if(sanitized_value == nullptr){
             // this UB needs to be post-bug analyzed, but its sanitized value cannot be found

--- a/pass/KSym/Oracle.cpp
+++ b/pass/KSym/Oracle.cpp
@@ -93,7 +93,7 @@ bool ModuleOracle::parseUserInputArg(string& path){
             
             //find func
             auto funcIt = func_str_map.find(funcName);
-            if(funcIt != func_str_map.end()){
+            if(funcIt == func_str_map.end()){
                 continue;
             }
             Function* func = funcIt->second;

--- a/pass/KSym/Propagation.cpp
+++ b/pass/KSym/Propagation.cpp
@@ -116,6 +116,8 @@ string UB_root::stringKind(formalize_kind kind) {
             return "unknown";
         case F_Calculated:
             return "calculated";
+        case F_Cmped:
+            return "cmped";
     }
 }
 


### PR DESCRIPTION
 For the case below, I find KUBO does not correctly label the user-controlled parameter `argp` with `F_USER`. I think the problem exists in `pass/Ksym/Oracle.cpp` when parsing previously generated `UserInputArg`. The PR tries to this problem. Please help validate the PR.
```c
int test(int __user *argp) {
    return 10 / *argp;
}
```
Thanks!